### PR TITLE
Another fix for MacOs...

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ chmod a+x mcia-irods-client-install.sh
 
 When installation is finished, you need to load iCommands into your shell environment:
 ```
+# if running MacOs (with Zsh) you must run this first : 
+#     autoload bashcompinit ; bashcompinit
 source $prefix/bashrc
 ```
 


### PR DESCRIPTION
It could be possible to add (hide!) these commands at the beginning of the $prefix/bashrc script, ignoring errors, just in case we are under zsh